### PR TITLE
Query position with radius as length

### DIFF
--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -100,6 +100,14 @@ which rows of the catalog matched, the sub-catalog of
 those rows ordered by separation from the search position,
 and the IDs of those sources also ordered by search position.
 
+The search radius may instaed be given as a length.  If so, it
+is an assumed physical proper radius and is therefore
+dependent on cosmology
+(astropy.cosmology.Plank15 is assumed).  Only sources with
+redshift z>1e-3 are considered. Example::
+
+    matches, sub_cat, IDs = sdb.qcat.query_position('001115.24+144601.9', 300*u.kpc)
+
 Here is an example with a wider search and restricting to
 sources that have spectra in at least one of a set of groups::
 

--- a/docs/catalog.rst
+++ b/docs/catalog.rst
@@ -100,10 +100,10 @@ which rows of the catalog matched, the sub-catalog of
 those rows ordered by separation from the search position,
 and the IDs of those sources also ordered by search position.
 
-The search radius may instaed be given as a length.  If so, it
+The search radius may instead be given as a length.  If so, it
 is an assumed physical proper radius and is therefore
 dependent on cosmology
-(astropy.cosmology.Plank15 is assumed).  Only sources with
+(astropy.cosmology.Planck15 is assumed).  Only sources with
 redshift z>1e-3 are considered. Example::
 
     matches, sub_cat, IDs = sdb.qcat.query_position('001115.24+144601.9', 300*u.kpc)

--- a/specdb/query_catalog.py
+++ b/specdb/query_catalog.py
@@ -411,9 +411,9 @@ class QueryCatalog(object):
             # Offset
             kpc_proper = self.cosmo.kpc_proper_per_arcmin(self.cat['zem'])
             phys_sep = kpc_proper * sep.to('arcmin')
+            good_z = self.cat['zem'] > 1e-3  # Floating point but somewhat arbitrary
             # Match
-            matches = phys_sep < radius
-            pdb.set_trace()
+            matches = (phys_sep < radius) & good_z
         else:
             # Match
             matches = sep < radius

--- a/specdb/specdb.py
+++ b/specdb/specdb.py
@@ -192,6 +192,8 @@ class SpecDB(object):
         ----------
         inp : coordinate in one of several formats
         radius : Angle or Quantity
+          If Quantity has dimensions of length (e.g. kpc), then
+          it is assumed a physical radius (dependent on Cosmology)
         query_dict : dict, optional
         groups : list, optional
           Restrict to input groups

--- a/specdb/specdb.py
+++ b/specdb/specdb.py
@@ -193,7 +193,7 @@ class SpecDB(object):
         inp : coordinate in one of several formats
         radius : Angle or Quantity
           If Quantity has dimensions of length (e.g. kpc), then
-          it is assumed a physical radius (dependent on Cosmology)
+          it is assumed a proper radius (dependent on Cosmology)
         query_dict : dict, optional
         groups : list, optional
           Restrict to input groups

--- a/specdb/tests/test_meta_query.py
+++ b/specdb/tests/test_meta_query.py
@@ -56,6 +56,9 @@ def test_meta_from_position(igmsp):
     meta = igmsp.meta_from_position((2.813500,14.767200), 20*u.deg, groups=['GGG','HD-LLS_DR1'])
     for group in meta['GROUP'].data:
         assert group in ['GGG', 'HD-LLS_DR1']
+    # Physical separation
+    meta6 = igmsp.meta_from_position('001115.23+144601.8', 300*u.kpc)
+    assert len(meta6) == 2
 
 
 def test_meta_from_coords(igmsp):


### PR DESCRIPTION
Overloads query_position() method to take radius as
an Angle or a Quantity length, e.g.  300*u.kpc

Test and docs