### PR TITLE
Fixing a new bug associated with an hdf5 update

### DIFF
--- a/specdb/build/privatedb.py
+++ b/specdb/build/privatedb.py
@@ -573,7 +573,7 @@ def mk_db(dbname, tree, outfil, iztbl, version='v00', id_key='PRIV_ID',
         if iztbl == 'igmspec':
             from specdb.specdb import IgmSpec
             igmsp = IgmSpec()
-            ztbl = Table(igmsp.idb.hdf['quasars'].value)
+            ztbl = Table(igmsp.idb.hdf['quasars'][...])
     elif isinstance(iztbl, Table):
         ztbl = iztbl
     else:

--- a/specdb/build/tests/test_privatedb.py
+++ b/specdb/build/tests/test_privatedb.py
@@ -54,7 +54,7 @@ def test_ingest():
     tmp = h5py.File('tmp.hdf5','r')
     # Test
     assert 'meta' in tmp['test'].keys()
-    assert isinstance(tmp['test/spec'].value, np.ndarray)
+    assert isinstance(tmp['test/spec'][...], np.ndarray)
 
 
 def test_mkdb():

--- a/specdb/build/utils.py
+++ b/specdb/build/utils.py
@@ -256,7 +256,7 @@ def chk_vstack(hdf):
     labels = []
     for key in hdf.keys():
         try:
-            meta = Table(hdf[key]['meta'].value)
+            meta = Table(hdf[key]['meta'][...])
         except (KeyError,ValueError):
             print("Skipping data group {:s}".format(key))
         else:

--- a/specdb/interface_group.py
+++ b/specdb/interface_group.py
@@ -67,7 +67,7 @@ class InterfaceGroup(object):
         group : str
         """
         import json
-        self.meta = spdbu.hdf_decode(self.hdf[group+'/meta'].value, itype='Table')
+        self.meta = spdbu.hdf_decode(self.hdf[group+'/meta'][...], itype='Table')
         # Attributes
         self.meta_attr = {}
         for key in self.hdf[group+'/meta'].attrs.keys():

--- a/specdb/query_catalog.py
+++ b/specdb/query_catalog.py
@@ -66,7 +66,7 @@ class QueryCatalog(object):
         """
         import json
         # Catalog and attributes
-        self.cat = Table(hdf['catalog'].value)
+        self.cat = Table(hdf['catalog'][...])
         self.cat_attr = {}
         for key in hdf['catalog'].attrs.keys():
             self.cat_attr[key] = spdbu.hdf_decode(hdf['catalog'].attrs[key])

--- a/specdb/scripts/specdb_chk.py
+++ b/specdb/scripts/specdb_chk.py
@@ -86,7 +86,7 @@ def main(pargs):
 
     # Sources and spectra
     print("-------------------------------------------------")
-    print("There are {:d} unique sources in the source catalog".format(len(hdf['catalog'].value)))
+    print("There are {:d} unique sources in the source catalog".format(len(hdf['catalog'][...])))
 
     # List datasets
     nspec = 0

--- a/specdb/specdb.py
+++ b/specdb/specdb.py
@@ -588,7 +588,7 @@ class IgmSpec(SpecDB):
 
         """
         from astropy.table import Table
-        return Table(self.idb.hdf['quasars'].value)
+        return Table(self.idb.hdf['quasars'][...])
 
     def __repr__(self):
         txt = '<{:s}:  IGM_file={:s} with {:d} sources\n'.format(self.__class__.__name__,


### PR DESCRIPTION
New versions of hdf5 have deprecated the Dataset.value syntax. See e.g. 

https://docs.h5py.org/en/stable/whatsnew/2.1.html

This breaks hdf5, so I've now fixed this following their documentation. I'm not sure whether

```
mydataset[...] or mydataset[()]
```
is correct. Both seem to do the same thing so I suspect they are equivalent.  I've grepped around looking  for other usages and I think I caught them all. One test is failing resulting from what appears to be an unrelated issue. 